### PR TITLE
Prefer ${prgnam}.SlackBuild over ${prgnam}

### DIFF
--- a/libexec/functions.d/parsefunctions.sh
+++ b/libexec/functions.d/parsefunctions.sh
@@ -204,8 +204,8 @@ function find_items
       prgnam=$(basename "$newitemid")
       dirnam="$newitemid"
       filenam=""
-      [ -f "$SR_SBREPO/${dirnam}/${prgnam}.SlackBuild" ] && filenam="${prgnam}.SlackBuild"
       [ -f "$SR_SBREPO/${dirnam}/${prgnam}" ] && filenam="${prgnam}"
+      [ -f "$SR_SBREPO/${dirnam}/${prgnam}.SlackBuild" ] && filenam="${prgnam}.SlackBuild"
     else # "$lookuptype" = '-s'
       filenam=$(basename "${object}")
       prgnam="${filenam%.SlackBuild}"


### PR DESCRIPTION
Prefer {$prgnam}.SlackBuild over ${prgnam} as name of the SlackBuild file, as old logic doesn't work with gcompris-qt.  It includes a file named gcompris-qt which slackrepo tries to use as the SlackBuild and fails.