### PR TITLE
Limit SlackBuilds indexing depth

### DIFF
--- a/libexec/functions.d/dbfunctions.sh
+++ b/libexec/functions.d/dbfunctions.sh
@@ -544,7 +544,7 @@ function db_index_slackbuilds
 # No parameters.
 {
   MY_SBLIST="$MYTMP"/sblist
-  ( cd "$SR_SBREPO"; find . -name '.git' -prune -o -type f -name '*.SlackBuild' -print | sed 's/^\.\///' > "$MY_SBLIST" )
+  ( cd "$SR_SBREPO"; find . -maxdepth 3 -name '.git' -prune -o -type f -name '*.SlackBuild' -print | sed 's/^\.\///' > "$MY_SBLIST" )
   echo -e \
     "drop table if exists slackbuilds; create table slackbuilds(relpath text);\n.mode csv\n.import $MY_SBLIST slackbuilds" \
     | sqlite3 "$SR_DATABASE"


### PR DESCRIPTION
Limit SlackBuilds indexing depth to `category/prgnam/prgnam.SlackBuild`.

It this way, it's possible to store original SlackBuild for reference together with the new SlackBuild version.

For example, I have a `slackup/git/git.SlackBuild`, that is based on the SlackBuild from stock Slackware. For reference, I store this stock SlackBuild in `slackup/git/git.SlackBuild.orig/git.SlackBuild`.

Without this change, `slackup/git/git.SlackBuild.orig/git.SlackBuild` is indexed and `slackrepo` tries to build it.